### PR TITLE
feature: add `Remove` and `Metadata` methods to the PQ Item API

### DIFF
--- a/plugins/v1/priority_queue/interface.go
+++ b/plugins/v1/priority_queue/interface.go
@@ -2,6 +2,8 @@ package priorityqueue
 
 // Queue is a binary heap interface
 type Queue interface {
+	// Remove removes element with provided ID (if exists) and returns that elements
+	Remove(id string) []Item
 	// PeekPriority returns the highest priority
 	PeekPriority() int64
 	// Insert adds an item to the queue
@@ -18,6 +20,8 @@ type Item interface {
 	ID() string
 	// Priority returns the priority level used to sort the item
 	Priority() int64
+	// Metadata returns the metadata for the item
+	Metadata() map[string][]string
 	// Body returns the payload associated with the item
 	Body() []byte
 	// Context returns any meta-information associated with the item


### PR DESCRIPTION
# Reason for This PR

- Support OTEL metadata and removing items from the PQ

## Description of Changes

- Add the `Metadata` method which returns `map[string][]string` with Item metadata.
- Add the `Remove(string id) []Item` method to the PQ interface to support items removing.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
