### PR TITLE
feat: add Connect-RPC service definitions for 6 plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 .idea
+.claude/settings.local.json

--- a/buf.yaml
+++ b/buf.yaml
@@ -3,6 +3,13 @@ modules:
   - path: roadrunner/api
   - path: third_party/api
 lint:
+  except:
+    # RR plugin RPCs share request/response types across methods (e.g. all
+    # LockService RPCs use LockRequest/LockResponse) and use domain-object
+    # names rather than the <Method>Request/<Method>Response convention.
+    - RPC_REQUEST_RESPONSE_UNIQUE
+    - RPC_REQUEST_STANDARD_NAME
+    - RPC_RESPONSE_STANDARD_NAME
   ignore:
     - third_party/api
     - roadrunner/api/centrifugo/api

--- a/buf.yaml
+++ b/buf.yaml
@@ -10,6 +10,9 @@ lint:
     - RPC_REQUEST_RESPONSE_UNIQUE
     - RPC_REQUEST_STANDARD_NAME
     - RPC_RESPONSE_STANDARD_NAME
+    # ServiceManager (service plugin RPC service) intentionally drops the
+    # "Service" suffix for readability.
+    - SERVICE_SUFFIX
   ignore:
     - third_party/api
     - roadrunner/api/centrifugo/api

--- a/roadrunner/api/applogger/v2/service.proto
+++ b/roadrunner/api/applogger/v2/service.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+
+package applogger.v2;
+
+import "applogger/v2/applogger.proto";
+
+option go_package = "github.com/roadrunner-server/api-go/v6/applogger/v2;apploggerV2";
+option php_metadata_namespace = "RoadRunner\\AppLogger\\DTO\\V2\\GPBMetadata";
+option php_namespace = "RoadRunner\\AppLogger\\DTO\\V2";
+
+// LogMessage carries a plain string log payload for the Error/Info/Warning/Debug/Log RPCs.
+// Domain-specific so future fields (level, caller skip, etc.) can be added without breaking the wire.
+message LogMessage {
+  string message = 1;
+}
+
+service AppLoggerService {
+  rpc Error(LogMessage) returns (LogResponse);
+  rpc ErrorWithContext(LogEntry) returns (LogResponse);
+  rpc Info(LogMessage) returns (LogResponse);
+  rpc InfoWithContext(LogEntry) returns (LogResponse);
+  rpc Warning(LogMessage) returns (LogResponse);
+  rpc WarningWithContext(LogEntry) returns (LogResponse);
+  rpc Debug(LogMessage) returns (LogResponse);
+  rpc DebugWithContext(LogEntry) returns (LogResponse);
+  rpc Log(LogMessage) returns (LogResponse);
+  rpc LogWithContext(LogEntry) returns (LogResponse);
+}

--- a/roadrunner/api/http/v2/service.proto
+++ b/roadrunner/api/http/v2/service.proto
@@ -11,17 +11,8 @@ option php_metadata_namespace = "RoadRunner\\HTTP\\DTO\\V2\\GPBMetadata";
 option php_namespace = "RoadRunner\\HTTP\\DTO\\V2";
 
 service HttpProxyService {
-  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
-  // buf:lint:ignore RPC_REQUEST_STANDARD_NAME
-  // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
   rpc FetchRequest(google.protobuf.Empty) returns (HttpHandlerRequest);
-  // buf:lint:ignore RPC_REQUEST_STANDARD_NAME
-  // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
   rpc FetchRequests(HttpHandlerFetchRequest) returns (HttpHandlerRequests);
-  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
   rpc HttpHandler(HttpHandlerRequest) returns (HttpHandlerResponse);
-  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
-  // buf:lint:ignore RPC_REQUEST_STANDARD_NAME
-  // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
   rpc HttpResponse(HttpHandlerResponse) returns (google.protobuf.Empty);
 }

--- a/roadrunner/api/jobs/v2/request.proto
+++ b/roadrunner/api/jobs/v2/request.proto
@@ -12,6 +12,12 @@ message JobsHandlerRequest {
   Job job = 1;
 }
 
+// PushRequest is the single-job variant of PushBatchRequest, used by JobsService.Push.
+// Proto-shape enforces single-job semantics; no runtime guard needed.
+message PushRequest {
+  Job job = 1;
+}
+
 message PushBatchRequest {
   repeated Job jobs = 1;
   // request headers

--- a/roadrunner/api/jobs/v2/service.proto
+++ b/roadrunner/api/jobs/v2/service.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package jobs.v2;
 
+import "google/protobuf/empty.proto";
+import "jobs/v2/jobs.proto";
 import "jobs/v2/request.proto";
 import "jobs/v2/response.proto";
 
@@ -9,6 +11,13 @@ option go_package = "github.com/roadrunner-server/api-go/v6/jobs/v2;jobsV2";
 option php_metadata_namespace = "RoadRunner\\Jobs\\DTO\\V2\\GPBMetadata";
 option php_namespace = "RoadRunner\\Jobs\\DTO\\V2";
 
-service JobsProxyService {
-  rpc JobsHandler(JobsHandlerRequest) returns (JobsHandlerResponse);
+service JobsService {
+  rpc Push(PushRequest) returns (JobsHandlerResponse);
+  rpc PushBatch(PushBatchRequest) returns (JobsHandlerResponse);
+  rpc Pause(Pipelines) returns (JobsHandlerResponse);
+  rpc Resume(Pipelines) returns (JobsHandlerResponse);
+  rpc List(google.protobuf.Empty) returns (Pipelines);
+  rpc Declare(DeclareRequest) returns (JobsHandlerResponse);
+  rpc Destroy(Pipelines) returns (Pipelines);
+  rpc GetStats(google.protobuf.Empty) returns (Stats);
 }

--- a/roadrunner/api/kv/v2/service.proto
+++ b/roadrunner/api/kv/v2/service.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package kv.v2;
+
+import "kv/v2/request.proto";
+import "kv/v2/response.proto";
+
+option go_package = "github.com/roadrunner-server/api-go/v6/kv/v2;kvV2";
+option php_metadata_namespace = "RoadRunner\\KV\\DTO\\V2\\GPBMetadata";
+option php_namespace = "RoadRunner\\KV\\DTO\\V2";
+
+service KvService {
+  rpc Has(KvRequest) returns (KvResponse);
+  rpc Set(KvRequest) returns (KvResponse);
+  rpc MGet(KvRequest) returns (KvResponse);
+  rpc MExpire(KvRequest) returns (KvResponse);
+  rpc TTL(KvRequest) returns (KvResponse);
+  rpc Delete(KvRequest) returns (KvResponse);
+  rpc Clear(KvRequest) returns (KvResponse);
+}

--- a/roadrunner/api/lock/v1/service.proto
+++ b/roadrunner/api/lock/v1/service.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package lock.v1;
+
+import "lock/v1/lock.proto";
+
+option go_package = "github.com/roadrunner-server/api-go/v6/lock/v1;lockV1";
+option php_metadata_namespace = "RoadRunner\\Lock\\DTO\\V1\\GPBMetadata";
+option php_namespace = "RoadRunner\\Lock\\DTO\\V1";
+
+service LockService {
+  rpc Lock(LockRequest) returns (LockResponse);
+  rpc LockRead(LockRequest) returns (LockResponse);
+  rpc Release(LockRequest) returns (LockResponse);
+  rpc ForceRelease(LockRequest) returns (LockResponse);
+  rpc Exists(LockRequest) returns (LockResponse);
+  rpc UpdateTTL(LockRequest) returns (LockResponse);
+}

--- a/roadrunner/api/service/v1/service_rpc.proto
+++ b/roadrunner/api/service/v1/service_rpc.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package service.v1;
+
+import "service/v1/service.proto";
+
+option go_package = "github.com/roadrunner-server/api-go/v6/service/v1;serviceV1";
+option php_metadata_namespace = "RoadRunner\\Service\\DTO\\V1\\GPBMetadata";
+option php_namespace = "RoadRunner\\Service\\DTO\\V1";
+
+// ServiceManager exposes lifecycle and status RPCs for the service plugin.
+// RPC method names are prefixed (CreateService, GetStatus, …) to avoid
+// collisions with same-named messages in this package (Create, Status, …).
+//
+// buf:lint:ignore SERVICE_SUFFIX
+service ServiceManager {
+  rpc CreateService(Create) returns (Response);
+  rpc Terminate(Service) returns (Response);
+  rpc Restart(Service) returns (Response);
+  rpc GetStatus(Service) returns (Status);
+  rpc GetStatuses(Service) returns (Statuses);
+  rpc ListServices(Service) returns (List);
+}

--- a/roadrunner/api/service/v1/service_rpc.proto
+++ b/roadrunner/api/service/v1/service_rpc.proto
@@ -11,8 +11,6 @@ option php_namespace = "RoadRunner\\Service\\DTO\\V1";
 // ServiceManager exposes lifecycle and status RPCs for the service plugin.
 // RPC method names are prefixed (CreateService, GetStatus, …) to avoid
 // collisions with same-named messages in this package (Create, Status, …).
-//
-// buf:lint:ignore SERVICE_SUFFIX
 service ServiceManager {
   rpc CreateService(Create) returns (Response);
   rpc Terminate(Service) returns (Response);

--- a/roadrunner/api/status/v2/service.proto
+++ b/roadrunner/api/status/v2/service.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package status.v2;
+
+import "status/v2/request.proto";
+import "status/v2/response.proto";
+
+option go_package = "github.com/roadrunner-server/api-go/v6/status/v2;statusV2";
+option php_metadata_namespace = "RoadRunner\\Status\\DTO\\V2\\GPBMetadata";
+option php_namespace = "RoadRunner\\Status\\DTO\\V2";
+
+service StatusService {
+  rpc Status(StatusRequest) returns (StatusResponse);
+  rpc Ready(StatusRequest) returns (StatusResponse);
+}


### PR DESCRIPTION
## Summary

Adds proto `service` blocks for the six RR plugins migrating from net/rpc + goridge codec to Connect-RPC: `app-logger`, `status`, `lock`, `kv`, `service`, `jobs`. Existing message types are reused where possible.

New messages introduced:
- `applogger/v2/LogMessage { string message = 1; }` for the primitive-string `Error`/`Info`/`Warning`/`Debug`/`Log` RPCs (domain-specific rather than `wrapperspb.StringValue`, leaves room for future fields).
- `jobs/v2/PushRequest { Job job = 1; }` for single-job pushes — shape-enforces single-job semantics, replaces the runtime `len(req.Batch) != 1` guard.

Naming changes to avoid same-package message/RPC collisions:
- `service.v1.ServiceManager`: `Create` → `CreateService`, `Status` → `GetStatus`, `Statuses` → `GetStatuses`, `List` → `ListServices`.
- `jobs.v2.JobsService`: `Stat` → `GetStats` (the `Stat` message exists in the same package).

Centralizes the RPC naming lints in `buf.yaml`: disables `RPC_REQUEST_RESPONSE_UNIQUE`, `RPC_REQUEST_STANDARD_NAME`, `RPC_RESPONSE_STANDARD_NAME` module-wide and drops the now-redundant per-method `// buf:lint:ignore` directives from `http/v2/service.proto`. RR plugin RPCs share request types across methods (e.g. all `LockService` RPCs use `LockRequest`/`LockResponse`) and use domain-object naming, so these rules are a structural mismatch.

Adds `.claude/settings.local.json` to `.gitignore`.

## Breaking changes

- `jobs/v2`: the placeholder `JobsProxyService.JobsHandler` is replaced by the multi-method `JobsService`. No live Go-side consumers — PHP still uses the goridge codec and migrates on its own timeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added logging service with multiple log levels (Error, Info, Warning, Debug).
  * Added key-value storage service with Set, Get, Delete, and TTL operations.
  * Added distributed lock service with read/write locking and TTL management.
  * Added service lifecycle management and status endpoints.
  * Enhanced job service with push, batch, and pipeline operations.

* **Chores**
  * Updated build configuration and local environment settings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roadrunner-server/api/pull/70)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->