### PR TITLE
feat(kv): mark Has, MGet, TTL as NO_SIDE_EFFECTS

### DIFF
--- a/roadrunner/api/kv/v2/service.proto
+++ b/roadrunner/api/kv/v2/service.proto
@@ -10,11 +10,17 @@ option php_metadata_namespace = "RoadRunner\\KV\\DTO\\V2\\GPBMetadata";
 option php_namespace = "RoadRunner\\KV\\DTO\\V2";
 
 service KvService {
-  rpc Has(KvRequest) returns (KvResponse);
+  rpc Has(KvRequest) returns (KvResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
   rpc Set(KvRequest) returns (KvResponse);
-  rpc MGet(KvRequest) returns (KvResponse);
+  rpc MGet(KvRequest) returns (KvResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
   rpc MExpire(KvRequest) returns (KvResponse);
-  rpc TTL(KvRequest) returns (KvResponse);
+  rpc TTL(KvRequest) returns (KvResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
   rpc Delete(KvRequest) returns (KvResponse);
   rpc Clear(KvRequest) returns (KvResponse);
 }


### PR DESCRIPTION
## Summary

Annotate the three read-only methods on `kv.v2.KvService` with `option idempotency_level = NO_SIDE_EFFECTS;`:

- `Has` — boolean existence check, no state change.
- `MGet` — read multiple values.
- `TTL` — read remaining TTL for keys.

Connect-RPC generates handlers that accept HTTP **GET** (in addition to POST) for methods carrying this annotation. That unlocks:

- Browser/CDN/forward-proxy caching of read responses without any server-side change.
- Natural URLs for read calls (a PHP client can hit `GET /kv.v2.KvService/MGet?message=...` directly).

`Set`, `MExpire`, `Delete`, `Clear` stay POST-only — they mutate state.

The annotation is additive: existing POST clients continue to work unchanged. After this PR lands, the `update-proto.yml` workflow on `api-go` will regenerate the Connect bindings and the next `api-go` `v6.0.0-beta.X` tag will pick up the new behavior.