### PR TITLE
feat(lock): mark Exists as NO_SIDE_EFFECTS

### DIFF
--- a/roadrunner/api/lock/v1/service.proto
+++ b/roadrunner/api/lock/v1/service.proto
@@ -13,6 +13,8 @@ service LockService {
   rpc LockRead(LockRequest) returns (LockResponse);
   rpc Release(LockRequest) returns (LockResponse);
   rpc ForceRelease(LockRequest) returns (LockResponse);
-  rpc Exists(LockRequest) returns (LockResponse);
+  rpc Exists(LockRequest) returns (LockResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
   rpc UpdateTTL(LockRequest) returns (LockResponse);
 }


### PR DESCRIPTION
## Summary

Annotate `Exists` on `lock.v1.LockService` with `option idempotency_level = NO_SIDE_EFFECTS;` — it's the only method on the service that doesn't mutate locker state.

The remaining methods stay POST-only because each of them changes server state:

- `Lock` / `LockRead` — acquire a lock; create the resource entry on first reference even when `wait=0`.
- `Release` / `ForceRelease` — drop ownership.
- `UpdateTTL` — modify TTL.

After this PR lands, `update-proto.yml` regenerates the Connect bindings on api-go, and the next `api-go` `v6.0.0-beta.X` tag will let callers probe lock existence via `GET /lock.v1.LockService/Exists?message=...`. Existing POST clients are unaffected.