### PR TITLE
feat(service): mark GetStatus, GetStatuses, ListServices as NO_SIDE_EFFECTS

### DIFF
--- a/roadrunner/api/service/v1/service_rpc.proto
+++ b/roadrunner/api/service/v1/service_rpc.proto
@@ -15,7 +15,13 @@ service ServiceManager {
   rpc CreateService(Create) returns (Response);
   rpc Terminate(Service) returns (Response);
   rpc Restart(Service) returns (Response);
-  rpc GetStatus(Service) returns (Status);
-  rpc GetStatuses(Service) returns (Statuses);
-  rpc ListServices(Service) returns (List);
+  rpc GetStatus(Service) returns (Status) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  rpc GetStatuses(Service) returns (Statuses) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  rpc ListServices(Service) returns (List) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
 }


### PR DESCRIPTION
## Summary

Annotate the three read-only methods on `service.v1.ServiceManager` with `option idempotency_level = NO_SIDE_EFFECTS;`:

- `GetStatus` — returns the status of a single service's first process. (Deprecated in favor of `GetStatuses`, but still served.)
- `GetStatuses` — returns per-process status for one service.
- `ListServices` — enumerates registered service names.

Connect-RPC generates handlers that accept HTTP **GET** (in addition to POST) for methods carrying this annotation. CDN/proxy/browser layers can cache the responses; PHP clients can probe via `GET /service.v1.ServiceManager/ListServices?message=...` directly.

`CreateService`, `Terminate`, `Restart` stay POST-only — each mutates the service plugin's internal process table.

The annotation is additive: existing POST clients continue to work unchanged. After this PR lands, `update-proto.yml` will regenerate the Connect bindings on api-go and the next api-go `v6.0.0-beta.X` tag will pick up the new behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Service status check operations are now explicitly marked as safe to retry without unintended side effects. This API enhancement improves reliability and consistency across service management workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roadrunner-server/api/pull/73)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->